### PR TITLE
Remove space separating the pseudo-class

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -170,8 +170,8 @@ nav a {
   fill: currentColor;
 }
 
-nav a :hover,
-nav a :focus {
+nav a:hover,
+nav a:focus {
   transition-duration: .6s;
   color: #f9013f;
 }
@@ -281,7 +281,7 @@ footer a {
 
 @media only screen and (min-width: 38em) {
 
-  .type-of-work section {
+  section .type-of-work {
     display: grid;
     grid-template-columns: 1fr 1fr;
     grid-template-rows: 1fr 1fr 1fr;
@@ -316,10 +316,6 @@ footer a {
     display: flex;
     flex-wrap: wrap;
     position: relative;
-  }
-
-  .contactinfo {
-    max-width: 50%;
   }
 
 }


### PR DESCRIPTION
when you add a space, will treat the pseudo selector like `nav a *:hover/focus` as in it's looking for the child to be hovered/focused (which explains why the focus state wasn't working because you can't get focus on the svg or span by default.

fixes #2 